### PR TITLE
[dark] Apply dark background to toast

### DIFF
--- a/dark/dark.scss
+++ b/dark/dark.scss
@@ -28,6 +28,7 @@ $swal2-progress-step-background: lighten($swal2-dark-theme-black, 25%);
 $swal2-button-focus-box-shadow: 0 0 0 1px $swal2-background, 0 0 0 3px $swal2-outline-color;
 
 // TOAST
+$swal2-toast-background: $swal2-dark-theme-black;
 $swal2-toast-button-focus-box-shadow: 0 0 0 1px $swal2-background, 0 0 0 3px $swal2-outline-color;
 
 @import '~sweetalert2/src/sweetalert2';


### PR DESCRIPTION
Commit https://github.com/sweetalert2/sweetalert2/commit/8ac68f1eaac2de37023141880fb641d7c62ef688 added a new variable for toast background `$swal2-toast-background`. This PR applies dark theme background color to toast using the newly added variable. 

Close #43 