### PR TITLE
Add wordpress admin theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Available themes
 - [`Borderless`](https://github.com/sweetalert2/sweetalert2-themes/tree/master/borderless)
 - [`Bootstrap 4`](https://github.com/sweetalert2/sweetalert2-themes/tree/master/bootstrap-4)
 - [`Material UI`](https://github.com/sweetalert2/sweetalert2-themes/tree/master/material-ui)
+- [`WordPress Admin`](https://github.com/sweetalert2/sweetalert2-themes/tree/master/wordpress-admin)
 - [`Default`](https://github.com/sweetalert2/sweetalert2-themes/tree/master/default)
 
 Installation

--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@
   
   if (toastOnly == 'true') {
     document.getElementById('toast-only').checked = true
-    const swalMixin = Swal.mixin({ title: theme, toast: true, timer: 3000 })
+    const swalMixin = Swal.mixin({ title: 'Settings updated.', toast: true, timer: 3000 })
     await swalMixin.fire()
     await swalMixin.fire({ position: 'bottom-start', timer: 10000, timerProgressBar: true, icon: 'success' })
     await swalMixin.fire({ position: 'bottom', showCancelButton: true })
@@ -45,15 +45,19 @@
     return
   }
 
-  const swalMixin = Swal.mixin({ title: theme })
+  // Add a title and caption to override the defaults
+  const title = '' || theme
+  const caption = ''
+
+  const swalMixin = Swal.mixin({ title: title })
   // Popup Type
-  await Swal.fire(theme, 'Caption', '')
-  await Swal.fire(theme, 'success!', 'success')
-  await Swal.fire(theme, 'error!', 'error')
-  await Swal.fire(theme, 'question!', 'question')
-  await Swal.fire(theme, 'warning!', 'warning')
-  await Swal.fire(theme, 'info!', 'info')
-  await Swal.fire(theme, 'question!', 'question')
+  await Swal.fire(title, caption ? caption : 'Caption!')
+  await Swal.fire(title, caption ? caption : 'success!', 'success')
+  await Swal.fire(title, caption ? caption : 'error!', 'error')
+  await Swal.fire(title, caption ? caption : 'question!', 'question')
+  await Swal.fire(title, caption ? caption : 'warning!', 'warning')
+  await Swal.fire(title, caption ? caption : 'info!', 'info')
+  await Swal.fire(title, caption ? caption : 'question!', 'question')
 
   // Buttons
   await swalMixin.fire({showCancelButton: true})

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <option value="borderless">Borderless</option>
     <option value="bootstrap-4">Bootstrap 4</option>
     <option value="material-ui">Material UI</option>
+    <option value="wordpress-admin">WordPress Admin</option>
   </select>
 
   <script src="./app.js"></script>

--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
         <option value="minimal">Minimal</option>
         <option value="borderless">Borderless</option>
         <option value="bootstrap-4">Bootstrap 4</option>
-		<option value="material-ui">Material UI</option>
-		<option value="wordpress-admin">WordPress Admin</option>
+        <option value="material-ui">Material UI</option>
+        <option value="wordpress-admin">WordPress Admin</option>
       </select>
     </div>
   

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp-autoprefixer": "^7.0.1",
     "gulp-clean-css": "^4.2.0",
     "gulp-header": "^2.0.9",
-    "gulp-rename": "^2.0.0",
+    "gulp-rename": "^1.2.2",
     "gulp-sass": "^4.0.2",
     "gulp-stylelint": "^10.0.0",
     "node-sass-tilde-importer": "^1.0.2",

--- a/wordpress-admin/README.md
+++ b/wordpress-admin/README.md
@@ -47,7 +47,7 @@ var notify = Swal.mixin({
   onBeforeOpen: (toast) => {
     
     // Offset the toast message based on the admin menu size
-    let dir = 'rtl' === document.dir ? 'right' : 'left'
+    var dir = 'rtl' === document.dir ? 'right' : 'left'
     toast.parentElement.style[dir] = document.getElementById('adminmenu').offsetWidth + 'px'
   }
 })

--- a/wordpress-admin/README.md
+++ b/wordpress-admin/README.md
@@ -1,4 +1,4 @@
-# @sweetalert2/theme-wordpress-admin - Wordpress-admin Theme for [SweetAlert2](https://github.com/sweetalert2/sweetalert2)
+# Wordpress-admin Theme for [SweetAlert2](https://github.com/sweetalert2/sweetalert2)
 
 [![npm version](https://img.shields.io/npm/v/@sweetalert2/theme-wordpress-admin.svg)](https://www.npmjs.com/package/@sweetalert2/theme-wordpress-admin)
 

--- a/wordpress-admin/README.md
+++ b/wordpress-admin/README.md
@@ -33,20 +33,23 @@ import Swal from 'sweetalert2/src/sweetalert2.js'
 @import '~@sweetalert2/theme-wordpress-admin/wordpress-admin.scss';
 ```
 
+Integration
+------------
+
 To more closely match the WordPress style toast messages, use the following to get started:
 
 ```js
 var notify = Swal.mixin({
-	toast: true,
-	position: 'bottom-start',
-	showConfirmButton: false,
-	timer: 60000,
-	onBeforeOpen: (toast) => {
-		
-		// Offset the toast message based on the admin menu size
-		let dir = 'rtl' === document.dir ? 'right' : 'left'
-		toast.parentElement.style[dir] = document.getElementById('adminmenu').offsetWidth + 'px'
-	}
+  toast: true,
+  position: 'bottom-start',
+  showConfirmButton: false,
+  timer: 60000,
+  onBeforeOpen: (toast) => {
+    
+    // Offset the toast message based on the admin menu size
+    let dir = 'rtl' === document.dir ? 'right' : 'left'
+    toast.parentElement.style[dir] = document.getElementById('adminmenu').offsetWidth + 'px'
+  }
 })
 ```
 
@@ -54,8 +57,8 @@ Further, when using icons you may wish to use [WordPress Dashicons](https://deve
 
 ```js
 notify.fire({
-	icon: 'success',
-	iconHtml: '<div class="dashicons dashicons-yes" style="transform: scale(3);"></div>',
-	title: 'Settings updated.',
+  icon: 'success',
+  iconHtml: '<div class="dashicons dashicons-yes" style="transform: scale(3);"></div>',
+  title: 'Settings updated.',
 })
 ```

--- a/wordpress-admin/README.md
+++ b/wordpress-admin/README.md
@@ -43,7 +43,7 @@ var notify = Swal.mixin({
   toast: true,
   position: 'bottom-start',
   showConfirmButton: false,
-  timer: 60000,
+  timer: 6000,
   onBeforeOpen: (toast) => {
     
     // Offset the toast message based on the admin menu size
@@ -53,7 +53,7 @@ var notify = Swal.mixin({
 })
 ```
 
-Further, when using icons you may wish to use [WordPress Dashicons](https://developer.wordpress.org/resource/dashicons/#editor-ul)
+Further, when using icons you may wish to use [WordPress Dashicons](https://developer.wordpress.org/resource/dashicons/#editor-ul).
 
 ```js
 notify.fire({

--- a/wordpress-admin/README.md
+++ b/wordpress-admin/README.md
@@ -32,3 +32,30 @@ import Swal from 'sweetalert2/src/sweetalert2.js'
 ```scss
 @import '~@sweetalert2/theme-wordpress-admin/wordpress-admin.scss';
 ```
+
+To more closely match the WordPress style toast messages, use the following to get started:
+
+```js
+var notify = Swal.mixin({
+	toast: true,
+	position: 'bottom-start',
+	showConfirmButton: false,
+	timer: 60000,
+	onBeforeOpen: (toast) => {
+		
+		// Offset the toast message based on the admin menu size
+		let dir = 'rtl' === document.dir ? 'right' : 'left'
+		toast.parentElement.style[dir] = document.getElementById('adminmenu').offsetWidth + 'px'
+	}
+})
+```
+
+Further, when using icons you may wish to use [WordPress Dashicons](https://developer.wordpress.org/resource/dashicons/#editor-ul)
+
+```js
+notify.fire({
+	icon: 'success',
+	iconHtml: '<div class="dashicons dashicons-yes" style="transform: scale(3);"></div>',
+	title: 'Settings updated.',
+})
+```

--- a/wordpress-admin/README.md
+++ b/wordpress-admin/README.md
@@ -53,12 +53,25 @@ var notify = Swal.mixin({
 })
 ```
 
-Further, when using icons you may wish to use [WordPress Dashicons](https://developer.wordpress.org/resource/dashicons/#editor-ul).
+Further, when using icons you may wish to use [WordPress Dashicons](https://developer.wordpress.org/resource/dashicons/).
 
 ```js
 notify.fire({
   icon: 'success',
   iconHtml: '<div class="dashicons dashicons-yes" style="transform: scale(3);"></div>',
   title: 'Settings updated.',
+})
+```
+
+Using modals as another example, you can add the Dashicon's [megaphone icon](https://developer.wordpress.org/resource/dashicons/#megaphone).
+
+```js
+Swal.fire({
+	title: 'Hey, we have something to say!',
+	confirmButtonText: 'Let\'s do this',
+	showCancelButton: false,
+	icon: 'info',
+	iconHtml: '<div class="dashicons dashicons-megaphone" style="transform: scale(3.5);"></div>',
+	text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.'
 })
 ```

--- a/wordpress-admin/README.md
+++ b/wordpress-admin/README.md
@@ -1,0 +1,34 @@
+# @sweetalert2/theme-wordpress-admin - Wordpress-admin Theme for [SweetAlert2](https://github.com/sweetalert2/sweetalert2)
+
+[![npm version](https://img.shields.io/npm/v/@sweetalert2/theme-wordpress-admin.svg)](https://www.npmjs.com/package/@sweetalert2/theme-wordpress-admin)
+
+Installation
+------------
+
+```sh
+npm install --save sweetalert2 @sweetalert2/theme-wordpress-admin
+```
+
+Usage
+-----
+
+With CSS:
+
+```html
+<!-- Include the Wordpress-admin theme -->
+<link rel="stylesheet" href="@sweetalert2/theme-wordpress-admin/wordpress-admin.css">
+
+<script src="sweetalert2/dist/sweetalert2.min.js"></script>
+```
+
+With SASS:
+
+`your-app.js`:
+```js
+import Swal from 'sweetalert2/src/sweetalert2.js'
+```
+
+`your-app.scss`:
+```scss
+@import '~@sweetalert2/theme-wordpress-admin/wordpress-admin.scss';
+```

--- a/wordpress-admin/README.md
+++ b/wordpress-admin/README.md
@@ -67,11 +67,11 @@ Using modals as another example, you can add the Dashicon's [megaphone icon](htt
 
 ```js
 Swal.fire({
-	title: 'Hey, we have something to say!',
-	confirmButtonText: 'Let\'s do this',
-	showCancelButton: false,
-	icon: 'info',
-	iconHtml: '<div class="dashicons dashicons-megaphone" style="transform: scale(3.5);"></div>',
-	text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.'
+  title: 'Hey, we have something to say!',
+  confirmButtonText: 'Let\'s do this',
+  showCancelButton: false,
+  icon: 'info',
+  iconHtml: '<div class="dashicons dashicons-megaphone" style="transform: scale(3.5);"></div>',
+  text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.'
 })
 ```

--- a/wordpress-admin/README.md
+++ b/wordpress-admin/README.md
@@ -39,7 +39,7 @@ Integration
 To more closely match the WordPress style toast messages, use the following to get started:
 
 ```js
-var notify = Swal.mixin({
+const notify = Swal.mixin({
   toast: true,
   position: 'bottom-start',
   showConfirmButton: false,
@@ -74,4 +74,11 @@ Swal.fire({
   iconHtml: '<div class="dashicons dashicons-megaphone" style="transform: scale(3.5);"></div>',
   text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.'
 })
+```
+
+If you would like to use this theme outside of the WordPress admin area, you might want to set the font-family to use the font WordPress uses:
+```css
+.swal2-container {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
 ```

--- a/wordpress-admin/animations.scss
+++ b/wordpress-admin/animations.scss
@@ -1,0 +1,33 @@
+@keyframes fadeInUpBig {
+  from {
+    transform: translate3d(0, 100%, 0);
+    opacity: 0;
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+}
+
+@keyframes fadeInUpTiny {
+  from {
+    transform: translate3d(0, 5px, 0);
+    opacity: 0.7;
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}

--- a/wordpress-admin/package.json
+++ b/wordpress-admin/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sweetalert2/theme-wordpress-admin",
+  "version": "3.0.7",
+  "repository": "sweetalert2/sweetalert2-themes",
+  "homepage": "https://sweetalert2.github.io/",
+  "description": "Wordpress theme for SweetAlert2",
+  "author": "",
+  "files": [
+    "*.css",
+    "*.scss"
+  ],
+  "main": "wordpress.css",
+  "keywords": [
+    "sweetalert2",
+    "wordpress",
+    "theme",
+    "themes",
+    "theming",
+    "sass"
+  ],
+  "bugs": "https://github.com/sweetalert2/sweetalert2-themes/issues",
+  "license": "MIT"
+}

--- a/wordpress-admin/package.json
+++ b/wordpress-admin/package.json
@@ -3,13 +3,13 @@
   "version": "3.0.7",
   "repository": "sweetalert2/sweetalert2-themes",
   "homepage": "https://sweetalert2.github.io/",
-  "description": "Wordpress admin theme for SweetAlert2",
+  "description": "WordPress admin theme for SweetAlert2",
   "author": "",
   "files": [
     "*.css",
     "*.scss"
   ],
-  "main": "wordpress.css",
+  "main": "wordpress-admin.css",
   "keywords": [
     "sweetalert2",
     "wordpress",

--- a/wordpress-admin/package.json
+++ b/wordpress-admin/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.7",
   "repository": "sweetalert2/sweetalert2-themes",
   "homepage": "https://sweetalert2.github.io/",
-  "description": "Wordpress theme for SweetAlert2",
+  "description": "Wordpress admin theme for SweetAlert2",
   "author": "",
   "files": [
     "*.css",

--- a/wordpress-admin/wordpress-admin.scss
+++ b/wordpress-admin/wordpress-admin.scss
@@ -50,7 +50,7 @@ $swal2-button-focus-box-shadow: 0 !important;
 
 // CONFIRM BUTTON
 $swal2-confirm-button-background-color: $wordpress-blue;
-$swal2-confirm-button-border: 1px solid $swal2-confirm-button-background-color !important;
+$swal2-confirm-button-border: 1px solid;
 $swal2-confirm-button-border-radius: 3px;
 $swal2-confirm-button-color: $swal2-dark-theme-white;
 $swal2-confirm-button-font-size: 13px;

--- a/wordpress-admin/wordpress-admin.scss
+++ b/wordpress-admin/wordpress-admin.scss
@@ -13,6 +13,9 @@ $swal2-outline-color: lighten($swal2-outline-color, 10%);
 $swal2-background: $swal2-dark-theme-black;
 $swal2-content-color: $swal2-dark-theme-white;
 
+$swal2-container-padding: 24px 16px;
+
+$swal2-title-margin: 0;
 $swal2-title-font-size: 30px;
 $swal2-title-color: $swal2-dark-theme-white;
 $swal2-backdrop: rgba(100, 100, 100, 0.5);
@@ -109,12 +112,6 @@ $swal2-timer-progress-bar-background: $wordpress-blue;
 
 @import '~sweetalert2/src/sweetalert2';
 
-// Overrides
-.swal2-container {
-  padding: 24px 16px;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-}
-
 .swal2-header {
   flex-direction: row;
   flex-wrap: wrap;
@@ -123,7 +120,6 @@ $swal2-timer-progress-bar-background: $wordpress-blue;
 }
 
 .swal2-title {
-  margin: 0;
   font-weight: 300;
   line-height: 30px;
 }
@@ -163,7 +159,6 @@ $swal2-timer-progress-bar-background: $wordpress-blue;
 .swal2-icon {
   height: 32px;
   transform: scale(0.7) translateY(24px);
-  animation: none !important;
   border: 0;
 }
 

--- a/wordpress-admin/wordpress-admin.scss
+++ b/wordpress-admin/wordpress-admin.scss
@@ -137,6 +137,8 @@ $swal2-timer-progress-bar-background: $wordpress-blue;
 }
 
 .swal2-progress-steps {
+  align-items: center;
+  justify-content: center;
   width: 100%;
 }
 
@@ -149,6 +151,7 @@ $swal2-timer-progress-bar-background: $wordpress-blue;
 
 .swal2-toast .swal2-title {
   font-weight: 400 !important;
+  line-height: 13px;
 }
 
 .swal2-icon {

--- a/wordpress-admin/wordpress-admin.scss
+++ b/wordpress-admin/wordpress-admin.scss
@@ -142,6 +142,10 @@ $swal2-timer-progress-bar-background: $wordpress-blue;
   width: 100%;
 }
 
+.swal2-toast .swal2-actions {
+  margin: 0 !important;
+}
+
 .swal2-toast .swal2-confirm,
 .swal2-toast .swal2-cancel {
   margin: 0 0 0 16px !important;

--- a/wordpress-admin/wordpress-admin.scss
+++ b/wordpress-admin/wordpress-admin.scss
@@ -1,0 +1,127 @@
+@import '~sweetalert2/src/variables';
+@import './animations';
+
+$wordpress-blue: rgb(0, 124, 186);
+$wordpress-red: #ca4a1f;
+$wordpress-green: #46b450;
+$wordpress-yellow: #ffb900;
+
+$swal2-dark-theme-black: #32373c;
+$swal2-dark-theme-white: #fff;
+$swal2-outline-color: lighten($swal2-outline-color, 10%);
+
+$swal2-background: $swal2-dark-theme-black;
+$swal2-content-color: $swal2-dark-theme-white;
+$swal2-title-color: $swal2-dark-theme-white;
+$swal2-backdrop: rgba(100, 100, 100, 0.25);
+
+// Animation
+$swal2-show-animation: fadeInUpTiny .5s;
+$swal2-hide-animation: fadeOut .25s;
+
+// PROGRESS STEPS
+$swal2-progress-step-background: white;
+$swal2-progress-step-color: #333;
+$swal2-active-step-background: $wordpress-blue;
+
+// ICONS
+$swal2-icon-animations: false;
+$swal2-icon-margin: 0 auto 16px;
+$swal2-icon-zoom: 0.7;
+$swal2-success: $wordpress-green;
+$swal2-error: $wordpress-red;
+$swal2-warning: $wordpress-yellow;
+$swal2-info: $wordpress-blue;
+$swal2-question: $wordpress-blue;
+
+// FOOTER
+$swal2-footer-border-color: #555;
+$swal2-footer-color: darken($swal2-content-color, 15%);
+
+// INPUT
+$swal2-input-color: $swal2-dark-theme-white;
+$swal2-input-background: lighten($swal2-dark-theme-black, 10%);
+
+// COMMON VARIABLES FOR CONFIRM AND CANCEL BUTTONS
+$swal2-button-darken-hover: transparent;
+$swal2-button-darken-active: transparent;
+$swal2-button-focus-background-color: none;
+$swal2-button-focus-box-shadow: 0 !important;
+
+// CONFIRM BUTTON
+$swal2-confirm-button-background-color: $wordpress-blue;
+$swal2-confirm-button-border: 1px solid $swal2-confirm-button-background-color !important;
+$swal2-confirm-button-border-radius: 3px;
+$swal2-confirm-button-color: $swal2-dark-theme-white;
+$swal2-confirm-button-font-size: 13px;
+
+// CANCEL BUTTON
+$swal2-cancel-button-border: 0 !default;
+$swal2-cancel-button-border-radius: .25em !default;
+$swal2-cancel-button-background-color: #aaa !default;
+$swal2-cancel-button-color: $swal2-white !default;
+$swal2-cancel-button-font-size: 13px;
+
+// VALIDATION MESSAGE
+$swal2-validation-message-background: lighten($swal2-dark-theme-black, 10%);
+$swal2-validation-message-color: $swal2-dark-theme-white;
+
+// TOAST
+$swal2-toast-show-animation: fadeInUpBig .65s;
+$swal2-toast-hide-animation: fadeOut 0.5s;
+$swal2-toast-background: $swal2-dark-theme-black;
+$swal2-toast-border: none !default;
+$swal2-toast-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+$swal2-toast-close-button-width: auto;
+$swal2-toast-close-button-height: auto;
+$swal2-toast-close-button-line-height: 16px;
+$swal2-toast-width: auto !default;
+$swal2-toast-padding: 16px 24px;
+$swal2-toast-title-margin: 0 .6em !default;
+$swal2-toast-title-font-size: 13px;
+$swal2-toast-content-font-size: 13px;
+$swal2-toast-input-font-size: 13px;
+$swal2-toast-validation-font-size: 13px;
+$swal2-toast-buttons-font-size: 13px;
+$swal2-toast-button-focus-box-shadow: 0 0 0 1px $swal2-background, 0 0 0 3px $swal2-outline-color !default;
+$swal2-toast-footer-margin: .5em 0 0 !default;
+$swal2-toast-footer-padding: .5em 0 0 !default;
+$swal2-toast-footer-font-size: 13px;
+
+// TIMER POGRESS BAR
+$swal2-timer-progress-bar-height: .25em;
+$swal2-timer-progress-bar-background: $wordpress-blue;
+
+@import '~sweetalert2/src/sweetalert2';
+
+// Overrides
+.swal2-container {
+  padding: 24px 16px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+.swal2-toast .swal2-confirm,
+.swal2-toast .swal2-cancel {
+  border: 0 !important;
+  background: none;
+  box-shadow: none !important;
+  text-decoration: underline;
+}
+
+.swal2-toast .swal2-title {
+  font-weight: 400 !important;
+}
+
+.swal2-popup.swal2-toast .swal2-icon {
+  transform: scale(0.7);
+  animation: none !important;
+  border: 0;
+}
+
+.swal2-popup.swal2-toast .swal2-success-ring {
+  display: none;
+}
+
+.swal2-popup.swal2-toast .swal2-icon * {
+  animation: none !important;
+}

--- a/wordpress-admin/wordpress-admin.scss
+++ b/wordpress-admin/wordpress-admin.scss
@@ -144,6 +144,8 @@ $swal2-timer-progress-bar-background: $wordpress-blue;
 
 .swal2-toast .swal2-confirm,
 .swal2-toast .swal2-cancel {
+  margin: 0 0 0 16px !important;
+  padding: 0 !important;
   background: none;
   box-shadow: none !important;
   text-decoration: underline;

--- a/wordpress-admin/wordpress-admin.scss
+++ b/wordpress-admin/wordpress-admin.scss
@@ -56,10 +56,6 @@ $swal2-confirm-button-color: $swal2-dark-theme-white;
 $swal2-confirm-button-font-size: 13px;
 
 // CANCEL BUTTON
-$swal2-cancel-button-border: 0 !default;
-$swal2-cancel-button-border-radius: .25em !default;
-$swal2-cancel-button-background-color: #aaa !default;
-$swal2-cancel-button-color: $swal2-white !default;
 $swal2-cancel-button-font-size: 13px;
 
 // VALIDATION MESSAGE
@@ -70,22 +66,16 @@ $swal2-validation-message-color: $swal2-dark-theme-white;
 $swal2-toast-show-animation: fadeInUpBig .65s;
 $swal2-toast-hide-animation: fadeOut 0.5s;
 $swal2-toast-background: $swal2-dark-theme-black;
-$swal2-toast-border: none !default;
 $swal2-toast-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 $swal2-toast-close-button-width: auto;
 $swal2-toast-close-button-height: auto;
 $swal2-toast-close-button-line-height: 16px;
-$swal2-toast-width: auto !default;
 $swal2-toast-padding: 16px 24px;
-$swal2-toast-title-margin: 0 .6em !default;
 $swal2-toast-title-font-size: 13px;
 $swal2-toast-content-font-size: 13px;
 $swal2-toast-input-font-size: 13px;
 $swal2-toast-validation-font-size: 13px;
 $swal2-toast-buttons-font-size: 13px;
-$swal2-toast-button-focus-box-shadow: 0 0 0 1px $swal2-background, 0 0 0 3px $swal2-outline-color !default;
-$swal2-toast-footer-margin: .5em 0 0 !default;
-$swal2-toast-footer-padding: .5em 0 0 !default;
 $swal2-toast-footer-font-size: 13px;
 
 // TIMER POGRESS BAR

--- a/wordpress-admin/wordpress-admin.scss
+++ b/wordpress-admin/wordpress-admin.scss
@@ -26,7 +26,7 @@ $swal2-active-step-background: $wordpress-blue;
 
 // ICONS
 $swal2-icon-animations: false;
-$swal2-icon-margin: 0 auto 16px;
+$swal2-icon-margin: 0 auto 24px;
 $swal2-icon-zoom: 0.7;
 $swal2-success: $wordpress-green;
 $swal2-error: $wordpress-red;
@@ -45,12 +45,11 @@ $swal2-input-background: lighten($swal2-dark-theme-black, 10%);
 // COMMON VARIABLES FOR CONFIRM AND CANCEL BUTTONS
 $swal2-button-darken-hover: transparent;
 $swal2-button-darken-active: transparent;
-$swal2-button-focus-background-color: none;
-$swal2-button-focus-box-shadow: 0 !important;
+$swal2-button-focus-box-shadow: 0 0 1px 1px;
 
 // CONFIRM BUTTON
 $swal2-confirm-button-background-color: $wordpress-blue;
-$swal2-confirm-button-border: 1px solid;
+$swal2-confirm-button-border: 0;
 $swal2-confirm-button-border-radius: 3px;
 $swal2-confirm-button-color: $swal2-dark-theme-white;
 $swal2-confirm-button-font-size: 13px;

--- a/wordpress-admin/wordpress-admin.scss
+++ b/wordpress-admin/wordpress-admin.scss
@@ -12,12 +12,23 @@ $swal2-outline-color: lighten($swal2-outline-color, 10%);
 
 $swal2-background: $swal2-dark-theme-black;
 $swal2-content-color: $swal2-dark-theme-white;
+
+$swal2-title-font-size: 30px;
 $swal2-title-color: $swal2-dark-theme-white;
-$swal2-backdrop: rgba(100, 100, 100, 0.25);
+$swal2-backdrop: rgba(100, 100, 100, 0.5);
 
 // Animation
 $swal2-show-animation: fadeInUpTiny .5s;
 $swal2-hide-animation: fadeOut .25s;
+
+// CONTENT
+$swal2-content-justify-content: flex-start;
+$swal2-content-text-align: left;
+$swal2-content-font-weight: lighter;
+
+// ACTIONS
+$swal2-actions-justify-content: flex-end;
+$swal2-actions-margin: 8px auto 0;
 
 // PROGRESS STEPS
 $swal2-progress-step-background: white;
@@ -26,7 +37,7 @@ $swal2-active-step-background: $wordpress-blue;
 
 // ICONS
 $swal2-icon-animations: false;
-$swal2-icon-margin: 0 auto 24px;
+$swal2-icon-margin: 0 0 0 -24px;
 $swal2-icon-zoom: 0.7;
 $swal2-success: $wordpress-green;
 $swal2-error: $wordpress-red;
@@ -39,8 +50,27 @@ $swal2-footer-border-color: #555;
 $swal2-footer-color: darken($swal2-content-color, 15%);
 
 // INPUT
+$swal2-input-height: 30px;
+$swal2-input-padding: 0 8px;
+$swal2-input-border: 1px solid #7e8993;
+$swal2-input-border-radius: 4px;
+$swal2-input-box-shadow: 0 0 0 transparent;
+$swal2-input-focus-border: 1px solid $wordpress-blue;
+$swal2-input-focus-outline: 2px solid transparent;
+$swal2-input-focus-box-shadow: 0 0 0 1px $wordpress-blue;
+$swal2-input-font-size: 14px;
+$swal2-input-background: lighten($swal2-dark-theme-black, 5%);
 $swal2-input-color: $swal2-dark-theme-white;
-$swal2-input-background: lighten($swal2-dark-theme-black, 10%);
+$swal2-input-transition: none;
+
+// VALIDATION MESSAGE
+$swal2-validation-message-justify-content: flex-start;
+$swal2-validation-message-padding: 4px 13px;
+$swal2-validation-message-background: transparent;
+$swal2-validation-message-color: $swal2-dark-theme-white;
+$swal2-validation-message-icon-background: $wordpress-red;
+$swal2-validation-message-icon-color: $swal2-white !default;
+$swal2-validation-message-icon-zoom: 0.7;
 
 // COMMON VARIABLES FOR CONFIRM AND CANCEL BUTTONS
 $swal2-button-darken-hover: transparent;
@@ -56,10 +86,6 @@ $swal2-confirm-button-font-size: 13px;
 
 // CANCEL BUTTON
 $swal2-cancel-button-font-size: 13px;
-
-// VALIDATION MESSAGE
-$swal2-validation-message-background: lighten($swal2-dark-theme-black, 10%);
-$swal2-validation-message-color: $swal2-dark-theme-white;
 
 // TOAST
 $swal2-toast-show-animation: fadeInUpBig .65s;
@@ -89,9 +115,33 @@ $swal2-timer-progress-bar-background: $wordpress-blue;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
+.swal2-header {
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin-bottom: 8px;
+}
+
+.swal2-title {
+  margin: 0;
+  font-weight: 300;
+  line-height: 30px;
+}
+
+.swal2-success-ring {
+  display: none;
+}
+
+.swal2-toast .swal2-header {
+  margin: 0 !important;
+}
+
+.swal2-progress-steps {
+  width: 100%;
+}
+
 .swal2-toast .swal2-confirm,
 .swal2-toast .swal2-cancel {
-  border: 0 !important;
   background: none;
   box-shadow: none !important;
   text-decoration: underline;
@@ -101,14 +151,10 @@ $swal2-timer-progress-bar-background: $wordpress-blue;
   font-weight: 400 !important;
 }
 
-.swal2-popup.swal2-toast .swal2-icon {
+.swal2-icon {
   transform: scale(0.7);
   animation: none !important;
   border: 0;
-}
-
-.swal2-popup.swal2-toast .swal2-success-ring {
-  display: none;
 }
 
 .swal2-popup.swal2-toast .swal2-icon * {

--- a/wordpress-admin/wordpress-admin.scss
+++ b/wordpress-admin/wordpress-admin.scss
@@ -37,7 +37,7 @@ $swal2-active-step-background: $wordpress-blue;
 
 // ICONS
 $swal2-icon-animations: false;
-$swal2-icon-margin: 0 0 0 -24px;
+$swal2-icon-margin: -36px -4px 0 -24px;
 $swal2-icon-zoom: 0.7;
 $swal2-success: $wordpress-green;
 $swal2-error: $wordpress-red;
@@ -161,11 +161,32 @@ $swal2-timer-progress-bar-background: $wordpress-blue;
 }
 
 .swal2-icon {
-  transform: scale(0.7);
+  height: 32px;
+  transform: scale(0.7) translateY(24px);
   animation: none !important;
   border: 0;
 }
 
+.swal2-icon.swal2-success {
+  transform: scale(0.7) translateY(4px);
+}
+
+.swal2-icon.swal2-error {
+  transform: scale(0.7) translateY(8px);
+}
+
+.swal2-success-circular-line-left {
+  display: none !important;
+}
+
 .swal2-popup.swal2-toast .swal2-icon * {
   animation: none !important;
+}
+
+.swal2-toast .swal2-icon {
+  transform: scale(0.7) translateY(-2px);
+}
+
+.swal2-toast .swal2-icon.swal2-success {
+  transform: scale(0.7) translateY(-5px);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,14 +138,14 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@sweetalert2/execute@^1.0.0":
+"@sweetalert2/execute@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@sweetalert2/execute/-/execute-1.0.1.tgz#4fb9b23750ef8ce0b91e77cbd73791b309516dda"
   integrity sha512-EqKwJXgDDn8VmIh1/lhcm2UjVv4RrPtwRmZz6BnymIjqKrxR23wrYK1fhYWpK3Sn0FtDljOXGHkHvmavqL9AGw==
   dependencies:
     execa "^2.0.0"
 
-"@sweetalert2/stylelint-config@^1.1.5":
+"@sweetalert2/stylelint-config@^1.1.23":
   version "1.1.23"
   resolved "https://registry.yarnpkg.com/@sweetalert2/stylelint-config/-/stylelint-config-1.1.23.tgz#e98ef59e05827483302d69cececf439a18b87066"
   integrity sha512-aG1SWcUE7oBJTEZfrLcK6NikV6xHnC/1rbDHCTyHTnRPILTegak8nARu9d/n0R1i/mGnX5iYLFzZn3ObVou4Hw==
@@ -677,7 +677,7 @@ browser-sync-ui@^2.26.4:
     socket.io-client "^2.0.4"
     stream-throttle "^0.1.3"
 
-browser-sync@^2.23.3:
+browser-sync@^2.26.7:
   version "2.26.7"
   resolved "https://registry.yarnpkg.com/browser-sync/-/browser-sync-2.26.7.tgz#120287716eb405651a76cc74fe851c31350557f9"
   integrity sha512-lY3emme0OyvA2ujEMpRmyRy9LY6gHLuTr2/ABxhIm3lADOiRXzP4dgekvnDrQqZ/Ec2Fz19lEjm6kglSG5766w==
@@ -2132,7 +2132,7 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
-gulp-autoprefixer@^7.0.0:
+gulp-autoprefixer@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/gulp-autoprefixer/-/gulp-autoprefixer-7.0.1.tgz#3c0dc26afc802d317e7560a7f760a0399049075a"
   integrity sha512-QJGEmHw+bEt7FSqvmbAUTxbCuNLJYx4sz3ox9WouYqT/7j5FH5CQ8ZnpL1M7H5npX1bUJa7lUVY1w20jXxhOxg==
@@ -2144,7 +2144,7 @@ gulp-autoprefixer@^7.0.0:
     through2 "^3.0.1"
     vinyl-sourcemaps-apply "^0.2.1"
 
-gulp-clean-css@^4.0.0:
+gulp-clean-css@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/gulp-clean-css/-/gulp-clean-css-4.2.0.tgz#915ec258dc6d3e6a50043f610066d5c2eac4f54e"
   integrity sha512-r4zQsSOAK2UYUL/ipkAVCTRg/2CLZ2A+oPVORopBximRksJ6qy3EX1KGrIWT4ZrHxz3Hlobb1yyJtqiut7DNjA==
@@ -2220,7 +2220,7 @@ gulp-stylelint@^10.0.0:
     strip-ansi "^5.2.0"
     through2 "^3.0.1"
 
-gulp@^4.0.0:
+gulp@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/gulp/-/gulp-4.0.2.tgz#543651070fd0f6ab0a0650c6a3e6ff5a7cb09caa"
   integrity sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==
@@ -4060,7 +4060,7 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-promise-polyfill@^8.1.0:
+promise-polyfill@^8.1.3:
   version "8.1.3"
   resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
   integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
@@ -4354,7 +4354,7 @@ replace-homedir@^1.0.0:
     is-absolute "^1.0.0"
     remove-trailing-separator "^1.1.0"
 
-replace-in-file@^4.0.0:
+replace-in-file@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-4.2.0.tgz#be779f4f61a8ee1ab9f917998bd36441673680fe"
   integrity sha512-9PGYDbU8iQF3W5a0Ariaf4KzYjsZSkonCYiZylwMiYOu0w5Bg9IuT4DqNnibA4zGNVxH//F7Hxh1P25TofAHGw==
@@ -5194,10 +5194,10 @@ svg-tags@^1.0.0:
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
 
-sweetalert2@^9.4.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-9.4.0.tgz#7dc06b09b830e201b5a51a2c84e52af3b8f396be"
-  integrity sha512-c9Azg2eVXIgaYV9Su2tRbRip7YD3baGwl9S7yKVdELu9E7rEcER+WBeJenVjR6kRGC426ggMFUgLTf0l/LUb1Q==
+sweetalert2@^9.5.2:
+  version "9.5.3"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-9.5.3.tgz#b280e218dc387a96fa2b6175b50d75421a708f7d"
+  integrity sha512-4wzLUCmVby3NPQC8XHp0HRJgTm5tbAO7OOaqabATNe0U6JN/oyBTS7iJJG9V83MpcP6MLDUEWcGO/Y8i6g2jYw==
 
 symbol-observable@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Let me know what you think. WordPress doesn't have modals so I basically just left it as the dark theme on modals and focused on the toast messages. if they ever add modals I'll come back and fix it :) 

I tried to make it look similar whether using the built-in Sweetalert2 icons or the built-in WordPress icons.

One thing I noticed that might be good to add is a class to the container that tells you which icon is active. Then for example, the timer bar color could reflect the current state. Not important though for this.

Some examples using the WP dashicon set against the WordPress admin panel:
<img width="680" alt="Screen Shot 2019-12-09 at 11 38 35 PM" src="https://user-images.githubusercontent.com/1478421/70455125-51767100-1ade-11ea-9458-72b1e748ea74.png">
<img width="680" alt="Screen Shot 2019-12-09 at 11 39 57 PM" src="https://user-images.githubusercontent.com/1478421/70455126-520f0780-1ade-11ea-9280-184f6f040914.png">
<img width="681" alt="Screen Shot 2019-12-09 at 11 41 20 PM" src="https://user-images.githubusercontent.com/1478421/70455127-520f0780-1ade-11ea-8852-1fb7318d4c42.png">
<img width="682" alt="Screen Shot 2019-12-09 at 11 39 30 PM" src="https://user-images.githubusercontent.com/1478421/70455131-52a79e00-1ade-11ea-9194-2ecde283f42a.png">

Modified sweetalert icon (border removed):
<img width="680" alt="Screen Shot 2019-12-09 at 11 42 48 PM" src="https://user-images.githubusercontent.com/1478421/70455133-52a79e00-1ade-11ea-9cb7-34d5845a920a.png">

Let me know if you want anything tweaked, updated, etc.
 
Closes https://github.com/sweetalert2/sweetalert2-themes/issues/39