### PR TITLE
feat: add Bulma theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 *.css
+.vscode

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Available themes
 - [`Bootstrap 4`](https://github.com/sweetalert2/sweetalert2-themes/tree/master/bootstrap-4)
 - [`Material UI`](https://github.com/sweetalert2/sweetalert2-themes/tree/master/material-ui)
 - [`WordPress Admin`](https://github.com/sweetalert2/sweetalert2-themes/tree/master/wordpress-admin)
+- [`Bulma`](https://github.com/sweetalert2/sweetalert2-themes/tree/master/bulma)
 - [`Default`](https://github.com/sweetalert2/sweetalert2-themes/tree/master/default)
 
 Installation

--- a/bulma/README.md
+++ b/bulma/README.md
@@ -1,0 +1,34 @@
+# @sweetalert2/theme-bulma - Bulma Theme for [SweetAlert2](https://github.com/sweetalert2/sweetalert2)
+
+[![npm version](https://img.shields.io/npm/v/@sweetalert2/theme-bulma.svg)](https://www.npmjs.com/package/@sweetalert2/theme-bulma)
+
+Installation
+------------
+
+```sh
+npm install --save sweetalert2 @sweetalert2/theme-bulma
+```
+
+Usage
+-----
+
+With CSS:
+
+```html
+<!-- Include the Bulma theme -->
+<link rel="stylesheet" href="@sweetalert2/theme-bulma/bulma.css">
+
+<script src="sweetalert2/dist/sweetalert2.min.js"></script>
+```
+
+With SASS:
+
+`your-app.js`:
+```js
+import Swal from 'sweetalert2/src/sweetalert2.js'
+```
+
+`your-app.scss`:
+```scss
+@import '~@sweetalert2/theme-bulma/bulma.scss';
+```

--- a/bulma/bulma.scss
+++ b/bulma/bulma.scss
@@ -1,0 +1,124 @@
+@import "~sweetalert2/src/variables";
+
+// override SASS variables here
+
+//
+// -- BULMA COPY VARIABLES
+// Colors
+
+$black: hsl(0, 0%, 4%) !default;
+$black-bis: hsl(0, 0%, 7%) !default;
+$black-ter: hsl(0, 0%, 14%) !default;
+
+$grey-darker: hsl(0, 0%, 21%) !default;
+$grey-dark: hsl(0, 0%, 29%) !default;
+$grey: hsl(0, 0%, 48%) !default;
+$grey-light: hsl(0, 0%, 71%) !default;
+$grey-lighter: hsl(0, 0%, 86%) !default;
+$grey-lightest: hsl(0, 0%, 93%) !default;
+
+$white-ter: hsl(0, 0%, 96%) !default;
+$white-bis: hsl(0, 0%, 98%) !default;
+$white: hsl(0, 0%, 100%) !default;
+
+$orange: hsl(14, 100%, 53%) !default;
+$yellow: hsl(48, 100%, 67%) !default;
+$green: hsl(141, 53%, 53%) !default;
+$turquoise: hsl(171, 100%, 41%) !default;
+$cyan: hsl(204, 71%, 53%) !default;
+$blue: hsl(217, 71%, 53%) !default;
+$purple: hsl(271, 100%, 71%) !default;
+$red: hsl(348, 86%, 61%) !default;
+
+$size-1: 3rem !default;
+$size-2: 2.5rem !default;
+$size-3: 2rem !default;
+$size-4: 1.5rem !default;
+$size-5: 1.25rem !default;
+$size-6: 1rem !default;
+$size-7: 0.75rem !default;
+
+$radius: 4px !default;
+
+$text-strong: rgb(54, 54, 54) !default;
+
+// Typography
+$family-sans-serif: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto",
+  "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+  "Helvetica", "Arial", sans-serif !default;
+$family-monospace: monospace !default;
+$render-mode: optimizeLegibility !default;
+
+$content-heading-color: $text-strong !default;
+
+$modal-background-background-color: rgba(10, 10, 10, 0.86);
+$family-primary: $family-sans-serif;
+$body-size: 16px !default;
+$radius-large: 6px !default;
+$body-font-size: 1em !default;
+$small-font-size: 0.875em !default;
+
+// -- BULMA COPY VARIABLES
+//
+
+// TITLE
+$swal2-title-color: $content-heading-color;
+$swal2-title-font-size: $size-3 !default;
+
+// BACKDROP
+$swal2-backdrop: $modal-background-background-color;
+$swal2-backdrop-transition: background-color 0.1s !default;
+
+// TYPOGRAPHY
+$swal2-font: $family-primary;
+$swal2-font-size: $body-size;
+
+// CONFIRM BUTTON
+$swal2-confirm-button-border: 0;
+$swal2-confirm-button-border-radius: $radius;
+$swal2-confirm-button-background-color: $turquoise;
+$swal2-confirm-button-color: $white;
+
+// CANCEL BUTTON
+// $swal2-cancel-button-border: 0;
+// $swal2-cancel-button-border-radius: $radius;
+// $swal2-cancel-button-background-color: rgba(255, 255, 255, 0);
+// $swal2-cancel-button-color: $material-ui-blue;
+
+// BUTTONS
+// $swal2-button-darken-hover: rgba($material-ui-blue, 0.1);
+// $swal2-button-darken-active: rgba($material-ui-blue, 0.3);
+// $swal2-button-focus-outline: #fff;
+
+// CONTENT
+$swal2-content-font-size: $body-size;
+
+// BOX MODEL
+$swal2-border-radius: $radius-large;
+$swal2-box-shadow: none;
+
+// ICONS
+$swal2-icon-animations: false;
+
+// INPUT
+$swal2-input-border-radius: 0;
+$swal2-input-box-shadow: none;
+$swal2-input-box-shadow-focus: none;
+$swal2-input-transition: initial;
+
+// ANIMATIONS
+$swal2-show-animation: none;
+$swal2-hide-animation: none;
+
+// CLOSE BUTTON
+$swal2-close-button-transition: initial;
+
+// TOASTS
+$swal2-toast-show-animation: none;
+$swal2-toast-hide-animation: none;
+$swal2-toast-success-line-tip-animation: none;
+$swal2-toast-success-line-long-animation: none;
+$swal2-toast-border: 1px solid lighten($swal2-black, 85);
+$swal2-toast-box-shadow: none;
+
+@import "~sweetalert2/src/sweetalert2";

--- a/bulma/bulma.scss
+++ b/bulma/bulma.scss
@@ -4,70 +4,86 @@
 
 //
 // -- BULMA COPY VARIABLES
+
 // Colors
+$black: hsl(0, 0%, 4%);
+$black-bis: hsl(0, 0%, 7%);
+$black-ter: hsl(0, 0%, 14%);
 
-$black: hsl(0, 0%, 4%) !default;
-$black-bis: hsl(0, 0%, 7%) !default;
-$black-ter: hsl(0, 0%, 14%) !default;
+$grey-darker: hsl(0, 0%, 21%);
+$grey-dark: hsl(0, 0%, 29%);
+$grey: hsl(0, 0%, 48%);
+$grey-light: hsl(0, 0%, 71%);
+$grey-lighter: hsl(0, 0%, 86%);
+$grey-lightest: hsl(0, 0%, 93%);
 
-$grey-darker: hsl(0, 0%, 21%) !default;
-$grey-dark: hsl(0, 0%, 29%) !default;
-$grey: hsl(0, 0%, 48%) !default;
-$grey-light: hsl(0, 0%, 71%) !default;
-$grey-lighter: hsl(0, 0%, 86%) !default;
-$grey-lightest: hsl(0, 0%, 93%) !default;
+$white-ter: hsl(0, 0%, 96%);
+$white-bis: hsl(0, 0%, 98%);
+$white: hsl(0, 0%, 100%);
 
-$white-ter: hsl(0, 0%, 96%) !default;
-$white-bis: hsl(0, 0%, 98%) !default;
-$white: hsl(0, 0%, 100%) !default;
+$orange: hsl(14, 100%, 53%);
+$yellow: hsl(48, 100%, 67%);
+$green: hsl(141, 53%, 53%);
+$turquoise: hsl(171, 100%, 41%);
+$cyan: hsl(204, 71%, 53%);
+$blue: hsl(217, 71%, 53%);
+$purple: hsl(271, 100%, 71%);
+$red: hsl(348, 86%, 61%);
 
-$orange: hsl(14, 100%, 53%) !default;
-$yellow: hsl(48, 100%, 67%) !default;
-$green: hsl(141, 53%, 53%) !default;
-$turquoise: hsl(171, 100%, 41%) !default;
-$cyan: hsl(204, 71%, 53%) !default;
-$blue: hsl(217, 71%, 53%) !default;
-$purple: hsl(271, 100%, 71%) !default;
-$red: hsl(348, 86%, 61%) !default;
+$text-strong: rgb(54, 54, 54);
 
-$size-1: 3rem !default;
-$size-2: 2.5rem !default;
-$size-3: 2rem !default;
-$size-4: 1.5rem !default;
-$size-5: 1.25rem !default;
-$size-6: 1rem !default;
-$size-7: 0.75rem !default;
+$content-heading-color: $text-strong;
 
-$radius: 4px !default;
+$primary: $turquoise;
 
-$text-strong: rgb(54, 54, 54) !default;
+$info: $cyan;
+$success: $green;
+$warning: $yellow;
+$danger: $red;
+
+$light: $white-ter;
+$dark: $grey-darker;
+
+// sizes
+$size-1: 3rem;
+$size-2: 2.5rem;
+$size-3: 2rem;
+$size-4: 1.5rem;
+$size-5: 1.25rem;
+$size-6: 1rem;
+$size-7: 0.75rem;
+
+//border
+$radius: 4px;
 
 // Typography
 $family-sans-serif: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto",
   "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-  "Helvetica", "Arial", sans-serif !default;
-$family-monospace: monospace !default;
-$render-mode: optimizeLegibility !default;
-
-$content-heading-color: $text-strong !default;
+  "Helvetica", "Arial", sans-serif;
+$family-monospace: monospace;
+$render-mode: optimizeLegibility;
 
 $modal-background-background-color: rgba(10, 10, 10, 0.86);
 $family-primary: $family-sans-serif;
-$body-size: 16px !default;
-$radius-large: 6px !default;
-$body-font-size: 1em !default;
-$small-font-size: 0.875em !default;
+$body-size: 16px;
+$radius-large: 6px;
+$body-font-size: 1em;
+$small-font-size: 0.875em;
+
+$modal-close-dimensions: 40px;
+$modal-close-right: 20px;
+$modal-close-top: 20px;
 
 // -- BULMA COPY VARIABLES
 //
 
 // TITLE
 $swal2-title-color: $content-heading-color;
-$swal2-title-font-size: $size-3 !default;
+$swal2-title-font-size: $size-3;
 
 // BACKDROP
 $swal2-backdrop: $modal-background-background-color;
-$swal2-backdrop-transition: background-color 0.1s !default;
+$swal2-backdrop-transition: background-color 0.1s;
 
 // TYPOGRAPHY
 $swal2-font: $family-primary;
@@ -87,10 +103,13 @@ $swal2-cancel-button-background-color: $white;
 $swal2-cancel-button-color: $grey-darker;
 $swal2-cancel-button-font-size: $size-6;
 
-// BUTTONS
-// $swal2-button-darken-hover: rgba($material-ui-blue, 0.1);
-// $swal2-button-darken-active: rgba($material-ui-blue, 0.3);
-// $swal2-button-focus-outline: #fff;
+// CLOSE BUTTON
+$swal2-close-button-width: $modal-close-dimensions;
+$swal2-close-button-height: $modal-close-dimensions;
+$swal2-close-button-position: fixed;
+$swal2-close-button-font-size: $size-4;
+$swal2-close-button-color: $swal2-white;
+$swal2-close-button-gap: $modal-close-top;
 
 // CONTENT
 $swal2-content-font-size: $body-size;
@@ -101,6 +120,12 @@ $swal2-box-shadow: none;
 
 // ICONS
 $swal2-icon-animations: false;
+$swal2-success: $success;
+$swal2-success-border: rgba($success, 0.3);
+$swal2-error: $danger;
+$swal2-warning: $warning;
+$swal2-info: $info;
+$swal2-question: $dark;
 
 // INPUT
 $swal2-input-border-radius: 0;
@@ -112,16 +137,12 @@ $swal2-input-transition: initial;
 $swal2-show-animation: none;
 $swal2-hide-animation: none;
 
-// CLOSE BUTTON
-$swal2-close-button-transition: initial;
-
 // TOASTS
 $swal2-toast-show-animation: none;
 $swal2-toast-hide-animation: none;
 $swal2-toast-success-line-tip-animation: none;
 $swal2-toast-success-line-long-animation: none;
 $swal2-toast-border: 1px solid lighten($swal2-black, 85);
-$swal2-toast-box-shadow: none;
 
 @import "~sweetalert2/src/sweetalert2";
 
@@ -129,4 +150,8 @@ $swal2-toast-box-shadow: none;
   &.swal2-cancel {
     font-weight: 400;
   }
+}
+
+.swal2-validation-message::before {
+  background-color: $danger;
 }

--- a/bulma/bulma.scss
+++ b/bulma/bulma.scss
@@ -78,12 +78,14 @@ $swal2-confirm-button-border: 0;
 $swal2-confirm-button-border-radius: $radius;
 $swal2-confirm-button-background-color: $turquoise;
 $swal2-confirm-button-color: $white;
+$swal2-confirm-button-font-size: $size-6;
 
 // CANCEL BUTTON
-// $swal2-cancel-button-border: 0;
-// $swal2-cancel-button-border-radius: $radius;
-// $swal2-cancel-button-background-color: rgba(255, 255, 255, 0);
-// $swal2-cancel-button-color: $material-ui-blue;
+$swal2-cancel-button-border: 1px solid $grey-lighter;
+$swal2-cancel-button-border-radius: $radius;
+$swal2-cancel-button-background-color: $white;
+$swal2-cancel-button-color: $grey-darker;
+$swal2-cancel-button-font-size: $size-6;
 
 // BUTTONS
 // $swal2-button-darken-hover: rgba($material-ui-blue, 0.1);
@@ -122,3 +124,9 @@ $swal2-toast-border: 1px solid lighten($swal2-black, 85);
 $swal2-toast-box-shadow: none;
 
 @import "~sweetalert2/src/sweetalert2";
+
+.swal2-styled {
+  &.swal2-cancel {
+    font-weight: 400;
+  }
+}

--- a/bulma/bulma.scss
+++ b/bulma/bulma.scss
@@ -56,6 +56,9 @@ $border-light-hover: $grey-light;
 
 $background: $white-ter;
 
+$input-arrow: $grey-light;
+$input-disabled-border-color: $white-ter;
+
 // sizes
 $size-1: 3rem;
 $size-2: 2.5rem;
@@ -199,4 +202,17 @@ $swal2-active-step-color: $white;
 .swal2-textarea:focus {
   border: 1px solid $input-focus-border-color;
   box-shadow: $input-focus-box-shadow-size $input-focus-box-shadow-color;
+}
+
+.swal2-input[disabled] {
+  border-color: whitesmoke;
+  background-color: whitesmoke;
+  box-shadow: none;
+  color: $grey-lighter;
+}
+
+.swal2-select {
+  border: 1px solid $grey-lighter;
+  border-radius: $radius;
+  color: $dark;
 }

--- a/bulma/bulma.scss
+++ b/bulma/bulma.scss
@@ -74,6 +74,8 @@ $modal-close-dimensions: 40px;
 $modal-close-right: 20px;
 $modal-close-top: 20px;
 
+$weight-normal: 400;
+
 // -- BULMA COPY VARIABLES
 //
 
@@ -148,7 +150,7 @@ $swal2-toast-border: 1px solid lighten($swal2-black, 85);
 
 .swal2-styled {
   &.swal2-cancel {
-    font-weight: 400;
+    font-weight: $weight-normal;
   }
 }
 

--- a/bulma/bulma.scss
+++ b/bulma/bulma.scss
@@ -30,7 +30,10 @@ $blue: hsl(217, 71%, 53%);
 $purple: hsl(271, 100%, 71%);
 $red: hsl(348, 86%, 61%);
 
-$text-strong: rgb(54, 54, 54);
+// Text colors
+$text: $grey-dark;
+$text-light: $grey;
+$text-strong: $grey-darker;
 
 $content-heading-color: $text-strong;
 
@@ -44,6 +47,15 @@ $danger: $red;
 $light: $white-ter;
 $dark: $grey-darker;
 
+$link: $blue;
+
+$border: $grey-lighter;
+$border-hover: $grey-light;
+$border-light: $grey-lightest;
+$border-light-hover: $grey-light;
+
+$background: $white-ter;
+
 // sizes
 $size-1: 3rem;
 $size-2: 2.5rem;
@@ -52,6 +64,7 @@ $size-4: 1.5rem;
 $size-5: 1.25rem;
 $size-6: 1rem;
 $size-7: 0.75rem;
+$control-height: 2.25em;
 
 //border
 $radius: 4px;
@@ -75,6 +88,23 @@ $modal-close-right: 20px;
 $modal-close-top: 20px;
 
 $weight-normal: 400;
+
+//input
+$input-color: $text-strong;
+$input-border-color: $border;
+$input-height: $control-height;
+$input-shadow: inset 0 0.0625em 0.125em rgba($dark, 0.05);
+$input-placeholder-color: rgba($input-color, 0.3);
+
+$input-hover-color: $text-strong;
+$input-hover-border-color: $border-hover;
+
+$input-focus-color: $text-strong;
+$input-focus-border-color: $link;
+$input-focus-box-shadow-size: 0 0 0 0.125em;
+$input-focus-box-shadow-color: rgba($link, 0.25);
+
+$input-radius: $radius;
 
 // -- BULMA COPY VARIABLES
 //
@@ -130,9 +160,9 @@ $swal2-info: $info;
 $swal2-question: $dark;
 
 // INPUT
-$swal2-input-border-radius: 0;
-$swal2-input-box-shadow: none;
-$swal2-input-box-shadow-focus: none;
+$swal2-input-border-radius: $radius;
+$swal2-input-box-shadow: inset 0 0.0625em 0.125em rgba($dark, 0.05);
+$swal2-input-box-shadow-focus: inset 0 0 0 0.125em rgba($link, 0.25);
 $swal2-input-transition: initial;
 
 // ANIMATIONS
@@ -146,6 +176,12 @@ $swal2-toast-success-line-tip-animation: none;
 $swal2-toast-success-line-long-animation: none;
 $swal2-toast-border: 1px solid lighten($swal2-black, 85);
 
+// PROGRESS STEPS
+$swal2-progress-step-background: $grey-lighter;
+$swal2-progress-step-color: $white;
+$swal2-active-step-background: $blue;
+$swal2-active-step-color: $white;
+
 @import "~sweetalert2/src/sweetalert2";
 
 .swal2-styled {
@@ -156,4 +192,11 @@ $swal2-toast-border: 1px solid lighten($swal2-black, 85);
 
 .swal2-validation-message::before {
   background-color: $danger;
+}
+
+.swal2-input:focus,
+.swal2-file:focus,
+.swal2-textarea:focus {
+  border: 1px solid $input-focus-border-color;
+  box-shadow: $input-focus-box-shadow-size $input-focus-box-shadow-color;
 }

--- a/bulma/package.json
+++ b/bulma/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sweetalert2/theme-bulma",
+  "version": "3.1.4",
+  "repository": "sweetalert2/sweetalert2-themes",
+  "homepage": "https://sweetalert2.github.io/",
+  "description": "Bulma theme for SweetAlert2",
+  "author": "",
+  "files": [
+    "*.css",
+    "*.scss"
+  ],
+  "main": "bulma.css",
+  "keywords": [
+    "sweetalert2",
+    "bulma",
+    "theme",
+    "themes",
+    "theming",
+    "sass"
+  ],
+  "bugs": "https://github.com/sweetalert2/sweetalert2-themes/issues",
+  "license": "MIT"
+}

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html>
+
 <head>
   <title>Themes for SweetAlert2</title>
 
@@ -25,12 +26,13 @@
         <option value="bootstrap-4">Bootstrap 4</option>
         <option value="material-ui">Material UI</option>
         <option value="wordpress-admin">WordPress Admin</option>
+        <option value="bulma">Bulma</option>
       </select>
     </div>
-  
+
     <div>
-        <input type="checkbox" id="toast-only" name="toast-only">
-        <label for="toast-only">Toast</label>
+      <input type="checkbox" id="toast-only" name="toast-only">
+      <label for="toast-only">Toast</label>
     </div>
   </div>
   <div style="max-width:1200px;margin:2rem auto 0">
@@ -54,4 +56,5 @@
 
   <script src="./app.js"></script>
 </body>
+
 </html>


### PR DESCRIPTION
Create theme files for https://bulma.io/

I created the theme following the provided guidelines and used a approach of using Bulma variables to define the sweetalert2 theme. The first section of the files are the Bulma vars and the second is theme itself that uses the Bulma vars. The ideia is that if we want to add other Bulma themes, we would need only yo change those Bulma vars.

Unfortunately I couldn't make the `select` component because Bulma uses a wrapping `div` for it, so we would have to make a HTML change in sweetalert2 to be able to do so. If you have any other ideia on how to fix this please let me know I'll fix it.

closes #13 