### PR TITLE
Add `!default` flag to dark theme variables

### DIFF
--- a/dark/dark.scss
+++ b/dark/dark.scss
@@ -1,7 +1,7 @@
 @import 'sweetalert2/src/variables';
 
-$swal2-dark-theme-black: #19191a;
-$swal2-dark-theme-white: #e1e1e1;
+$swal2-dark-theme-black: #19191a !default;
+$swal2-dark-theme-white: #e1e1e1 !default;
 $swal2-outline-color: lighten($swal2-outline-color, 10%);
 
 $swal2-background: $swal2-dark-theme-black;


### PR DESCRIPTION
This change allows users to override these variables during their project setup using the `@use` rule, as documented on the SCSS [website](https://sass-lang.com/documentation/variables/#configuring-modules)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Style**
	- Updated default color variables for dark theme settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->